### PR TITLE
Removes start-of-line matching restriction for kernel_name in get_stats.py

### DIFF
--- a/util/job_launching/get_stats.py
+++ b/util/job_launching/get_stats.py
@@ -282,7 +282,7 @@ for idx, app_and_args in enumerate(apps_and_args):
                         if current_kernel + app_and_args + config + stat_name in stat_map:
                             del stat_map[current_kernel + app_and_args + config + stat_name]
 
-                kernel_match = re.match("kernel_name\s+=\s+(.*)", line);
+                kernel_match = re.search("kernel_name\s+=\s+(.*)", line);
                 if kernel_match:
                     last_kernel = current_kernel
                     current_kernel = kernel_match.group(1).strip()


### PR DESCRIPTION
If the benchmark happens to use printf() upon kernel completion without '\n', "kernel_name = blahblah" might not appear at the start of the line, in which case re.match() will not find the kernel and the produced table would have mismatched data. Changing it to re.search() to allow matching in the middle of a line.